### PR TITLE
Add HTTP transport support to Sequential Thinking server

### DIFF
--- a/src/sequentialthinking/Dockerfile
+++ b/src/sequentialthinking/Dockerfile
@@ -9,6 +9,8 @@ RUN --mount=type=cache,target=/root/.npm npm install
 
 RUN --mount=type=cache,target=/root/.npm-production npm ci --ignore-scripts --omit-dev
 
+RUN npm run build
+
 FROM node:22-alpine AS release
 
 COPY --from=builder /app/dist /app/dist
@@ -16,9 +18,14 @@ COPY --from=builder /app/package.json /app/package.json
 COPY --from=builder /app/package-lock.json /app/package-lock.json
 
 ENV NODE_ENV=production
+ENV HOST=0.0.0.0
+ENV PORT=3000
 
 WORKDIR /app
 
 RUN npm ci --ignore-scripts --omit-dev
 
-ENTRYPOINT ["node", "dist/index.js"]
+EXPOSE 3000
+EXPOSE 3001
+
+ENTRYPOINT ["node", "dist/index.js", "--transport", "http", "--port", "3000", "--host", "0.0.0.0"]

--- a/src/sequentialthinking/README.md
+++ b/src/sequentialthinking/README.md
@@ -10,6 +10,7 @@ An MCP server implementation that provides a tool for dynamic and reflective pro
 - Branch into alternative paths of reasoning
 - Adjust the total number of thoughts dynamically
 - Generate and verify solution hypotheses
+- HTTP transport by default for easy deployment
 
 ## Tool
 
@@ -39,6 +40,15 @@ The Sequential Thinking tool is designed for:
 - Situations where irrelevant information needs to be filtered out
 
 ## Configuration
+
+### Command Line Options
+
+The server supports the following command line options:
+
+- `--transport, -t`: Transport type (stdio or http, default: http)
+- `--port, -p`: HTTP port to listen on (default: 3000)
+- `--host, -h`: Host to bind to (default: 0.0.0.0)
+- `--help, -?`: Show help
 
 ### Usage with Claude Desktop
 
@@ -84,6 +94,29 @@ Docker:
 
 ```bash
 docker build -t mcp/sequentialthinking -f src/sequentialthinking/Dockerfile .
+```
+
+## Running as HTTP Server
+
+This fork has been modified to run as an HTTP server by default, making it easier to deploy to cloud environments.
+
+```bash
+# Run via npm
+npm start
+
+# Run with custom port
+npm start -- --port 8080
+
+# Run with stdio transport (original behavior)
+npm start -- --transport stdio
+```
+
+## Health Check
+
+A health check endpoint is available at `/health` on port 3001 (port + 1) when running in HTTP mode:
+
+```
+http://localhost:3001/health
 ```
 
 ## License

--- a/src/sequentialthinking/package.json
+++ b/src/sequentialthinking/package.json
@@ -16,7 +16,8 @@
   "scripts": {
     "build": "tsc && shx chmod +x dist/*.js",
     "prepare": "npm run build",
-    "watch": "tsc --watch"
+    "watch": "tsc --watch",
+    "start": "node dist/index.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "0.5.0",


### PR DESCRIPTION
This PR modifies the Sequential Thinking MCP server to use HTTP transport by default instead of stdio, making it easier to deploy to cloud environments and servers.

Changes include:
- Added HTTP transport option with command line parameters (--transport, --port, --host)
- Set HTTP as the default transport mode
- Added health check endpoint on port+1 for monitoring
- Updated Dockerfile to expose ports and set environment variables
- Updated README with new usage instructions
- Added yargs for command line argument handling

These changes allow the server to be easily deployed to platforms like Coolify without modification.