### PR TITLE
Simple HTTP server implementation for Sequential Thinking

### DIFF
--- a/src/sequentialthinking/Dockerfile
+++ b/src/sequentialthinking/Dockerfile
@@ -1,31 +1,29 @@
-FROM node:22.12-alpine AS builder
-
-COPY src/sequentialthinking /app
-COPY tsconfig.json /tsconfig.json
+FROM node:18-alpine
 
 WORKDIR /app
 
-RUN --mount=type=cache,target=/root/.npm npm install
+# Copy package.json and package-lock.json files
+COPY src/sequentialthinking/package*.json ./
 
-RUN --mount=type=cache,target=/root/.npm-production npm ci --ignore-scripts --omit-dev
+# Install dependencies
+RUN npm install
 
+# Copy TypeScript configuration files
+COPY tsconfig.json /tsconfig.json
+
+# Copy source code
+COPY src/sequentialthinking/*.ts ./
+
+# Build the application
 RUN npm run build
 
-FROM node:22-alpine AS release
-
-COPY --from=builder /app/dist /app/dist
-COPY --from=builder /app/package.json /app/package.json
-COPY --from=builder /app/package-lock.json /app/package-lock.json
-
+# Set environment variables
 ENV NODE_ENV=production
 ENV HOST=0.0.0.0
 ENV PORT=3000
 
-WORKDIR /app
-
-RUN npm ci --ignore-scripts --omit-dev
-
+# Expose port
 EXPOSE 3000
-EXPOSE 3001
 
-ENTRYPOINT ["node", "dist/index.js", "--transport", "http", "--port", "3000", "--host", "0.0.0.0"]
+# Run the application
+CMD ["node", "dist/index.js", "--transport", "http", "--port", "3000", "--host", "0.0.0.0"]

--- a/src/sequentialthinking/README.md
+++ b/src/sequentialthinking/README.md
@@ -10,7 +10,7 @@ An MCP server implementation that provides a tool for dynamic and reflective pro
 - Branch into alternative paths of reasoning
 - Adjust the total number of thoughts dynamically
 - Generate and verify solution hypotheses
-- HTTP transport by default for easy deployment
+- HTTP server support for easy deployment
 
 ## Tool
 
@@ -49,6 +49,28 @@ The server supports the following command line options:
 - `--port, -p`: HTTP port to listen on (default: 3000)
 - `--host, -h`: Host to bind to (default: 0.0.0.0)
 - `--help, -?`: Show help
+
+### Using with HTTP
+
+You can test the HTTP server with the following curl commands:
+
+```bash
+# Health check
+curl http://localhost:3000/health
+
+# List available tools
+curl -X POST http://localhost:3000/mcp/v1/tools
+
+# Call the sequential_thinking tool
+curl -X POST http://localhost:3000/mcp/v1/tools/sequentialthinking \
+  -H "Content-Type: application/json" \
+  -d '{
+    "thought": "Initial problem analysis",
+    "nextThoughtNeeded": true,
+    "thoughtNumber": 1,
+    "totalThoughts": 5
+  }'
+```
 
 ### Usage with Claude Desktop
 
@@ -111,13 +133,15 @@ npm start -- --port 8080
 npm start -- --transport stdio
 ```
 
-## Health Check
+## Deploying to Coolify
 
-A health check endpoint is available at `/health` on port 3001 (port + 1) when running in HTTP mode:
+To deploy this server to Coolify:
 
-```
-http://localhost:3001/health
-```
+1. Fork this repository
+2. In Coolify, create a new service using this repository
+3. Set the Dockerfile path to `src/sequentialthinking/Dockerfile`
+4. Set the build context to `/` (root directory)
+5. Deploy the application
 
 ## License
 

--- a/src/sequentialthinking/package.json
+++ b/src/sequentialthinking/package.json
@@ -22,9 +22,11 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "0.5.0",
     "chalk": "^5.3.0",
+    "express": "^4.19.2",
     "yargs": "^17.7.2"
   },
   "devDependencies": {
+    "@types/express": "^4.17.21",
     "@types/node": "^22",
     "@types/yargs": "^17.0.32",
     "shx": "^0.3.4",


### PR DESCRIPTION
This PR adds a simple HTTP server implementation for Sequential Thinking using Express, which is more compatible with the current dependencies.

Changes include:
- Added Express.js for HTTP server implementation
- Left original stdio transport functionality intact
- Uses command line arguments to select transport type (default: http)
- Simplified Dockerfile for better build compatibility
- Updated documentation with deployment instructions

This approach doesn't rely on HttpServerTransport from the SDK, which appears to be missing in the current version, and instead uses Express directly.